### PR TITLE
Replaces the upsert action

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/onyx-elasticsearch "0.9.15.0"
+(defproject org.clojars.jgerman/onyx-elasticsearch "0.9.15.1-SNAPSHOT"
   :description "Onyx plugin for Elasticsearch"
   :url "https://github.com/onyx-platform/onyx-elasticsearch"
   :license {:name "Eclipse Public License"

--- a/src/onyx/plugin/elasticsearch.clj
+++ b/src/onyx/plugin/elasticsearch.clj
@@ -222,7 +222,7 @@
     (case write-type
       :insert (run-as client-type :create cxn index mapping doc :id doc-id)
       :insert-noid (run-as client-type :create cxn index mapping doc)
-      :upsert (run-as client-type :put cxn index mapping doc-id doc)
+      :upsert (run-as client-type :upsert cxn index mapping doc-id doc)
       :upsert-noid (run-as client-type :create cxn index mapping doc)
       :delete (run-as client-type :delete cxn index mapping doc-id)
       :default (throw (Exception. (str "Invalid write type: " write-type))))))


### PR DESCRIPTION
The elastisch version this depended on didn't have a 'real' upsert. This
commit bumps elastisch to 2.2.2 and changes the docid present version of
the plugin's upsert command to use elastich's upsert.